### PR TITLE
Add admin nav link

### DIFF
--- a/frontend/components/Layout.js
+++ b/frontend/components/Layout.js
@@ -13,6 +13,7 @@ export default function Layout({ children }) {
             <Link href="/search" className="hover:underline">Search</Link>
             <Link href="/export" className="hover:underline">Export</Link>
             <Link href="/summary" className="hover:underline">Summary</Link>
+            <Link href="/admin" className="hover:underline">Admin</Link>
           </div>
         </div>
       </nav>


### PR DESCRIPTION
## Summary
- expose the Admin page in the site navigation

## Testing
- `npm run build` *(fails: next not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845bcf9c154832cb15e9a55d019c48b