### PR TITLE
Add Microsoft Entra authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ The backend expects several OpenAI related variables which can be provided via `
 - `AZURE_OPENAI_VISION_DEPLOYMENT` – vision/chat deployment name
 - `AZURE_OPENAI_API_VERSION` – API version string
 
+For authentication using Microsoft Entra ID (Azure AD) set the following in `.env`:
+- `AZURE_AD_CLIENT_ID` – Entra application (client) ID
+- `AZURE_AD_CLIENT_SECRET` – client secret
+- `AZURE_AD_TENANT_ID` – directory/tenant ID
+- `AZURE_AD_REDIRECT_URI` – OAuth redirect URL for NextAuth
+- `NEXTAUTH_SECRET` – secret used to sign JWT sessions
+- `NODE_ENV` – `production` to enforce authentication, `development` to skip it
+- `ALLOWED_EMAILS` – comma separated list of allowed user emails *(optional)*
+- `POSTGRES_URL` – connection string to a Postgres database containing an `allowed_users` table *(optional)*
+
+## 🔐 Microsoft Entra Setup
+1. Create a new **App registration** in the Azure portal.
+2. Add your callback URL (e.g. `http://localhost:3000/api/auth/callback/azure-ad`) as a **Redirect URI**.
+3. Copy the **Application (client) ID** and **Directory (tenant) ID**.
+4. Create a **Client Secret** and note the value.
+5. Set the environment variables from the list above and start the app with `NODE_ENV=production` to require sign in.
+
 ---
 
 ## 🧪 Getting Started

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,46 @@
+import os
+from typing import Set
+from jose import jwt, JWTError
+from fastapi import HTTPException, Request
+
+import psycopg2
+
+_cached_emails: Set[str] | None = None
+
+def load_allowed_emails() -> Set[str]:
+    global _cached_emails
+    if _cached_emails is not None:
+        return _cached_emails
+    env = os.environ.get("ALLOWED_EMAILS")
+    if env:
+        _cached_emails = {e.strip().lower() for e in env.split(',') if e.strip()}
+        return _cached_emails
+    db_url = os.environ.get("POSTGRES_URL")
+    if db_url:
+        conn = psycopg2.connect(db_url)
+        cur = conn.cursor()
+        cur.execute("SELECT email FROM allowed_users")
+        rows = cur.fetchall()
+        cur.close()
+        conn.close()
+        _cached_emails = {r[0].lower() for r in rows}
+        return _cached_emails
+    _cached_emails = set()
+    return _cached_emails
+
+def verify_session(request: Request):
+    if os.environ.get("NODE_ENV") != "production":
+        return
+    token = request.cookies.get("next-auth.session-token")
+    if not token:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    try:
+        payload = jwt.decode(token, os.environ["NEXTAUTH_SECRET"], algorithms=["HS256"])
+        email = payload.get("email")
+        if not email:
+            raise HTTPException(status_code=401, detail="Invalid token")
+        allowed = load_allowed_emails()
+        if email.lower() not in allowed:
+            raise HTTPException(status_code=403, detail="Access denied")
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid token")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,5 @@ requests
 python-dotenv
 faiss-cpu
 openai
+python-jose[cryptography]
+psycopg2-binary

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ./uploads:/app/uploads
     environment:
       - PYTHONUNBUFFERED=1
+      - NODE_ENV=development
 
   frontend:
     build: ./frontend
@@ -17,5 +18,7 @@ services:
       - "3000:3000"
     volumes:
       - ./frontend:/app
+    environment:
+      - NODE_ENV=development
     depends_on:
       - backend

--- a/frontend/components/Layout.js
+++ b/frontend/components/Layout.js
@@ -1,7 +1,10 @@
 // frontend/components/Layout.js
 import Link from 'next/link';
+import { signIn, signOut, useSession } from 'next-auth/react';
 
 export default function Layout({ children }) {
+  const { data: session } = useSession();
+  const isProd = process.env.NODE_ENV === 'production';
   return (
     <div className="min-h-screen bg-gray-50">
       <nav className="bg-blue-600 text-white px-6 py-4 shadow">
@@ -14,6 +17,17 @@ export default function Layout({ children }) {
             <Link href="/export" className="hover:underline">Export</Link>
             <Link href="/summary" className="hover:underline">Summary</Link>
             <Link href="/admin" className="hover:underline">Admin</Link>
+            {isProd && (
+              session ? (
+                <button onClick={() => signOut()} className="ml-4 underline">
+                  Sign out
+                </button>
+              ) : (
+                <button onClick={() => signIn()} className="ml-4 underline">
+                  Sign in
+                </button>
+              )
+            )}
           </div>
         </div>
       </nav>

--- a/frontend/lib/allowedEmails.js
+++ b/frontend/lib/allowedEmails.js
@@ -1,0 +1,27 @@
+let cachedEmails = null;
+const { Client } = require('pg');
+
+async function loadFromDB() {
+  const client = new Client({ connectionString: process.env.POSTGRES_URL });
+  await client.connect();
+  const res = await client.query('SELECT email FROM allowed_users');
+  await client.end();
+  return res.rows.map(r => r.email.toLowerCase());
+}
+
+export async function getAllowedEmails() {
+  if (cachedEmails) return cachedEmails;
+
+  if (process.env.ALLOWED_EMAILS) {
+    cachedEmails = process.env.ALLOWED_EMAILS.split(',')
+      .map(e => e.trim().toLowerCase())
+      .filter(Boolean);
+    return cachedEmails;
+  }
+  if (process.env.POSTGRES_URL) {
+    cachedEmails = await loadFromDB();
+    return cachedEmails;
+  }
+  cachedEmails = [];
+  return cachedEmails;
+}

--- a/frontend/middleware.js
+++ b/frontend/middleware.js
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+
+export async function middleware(req) {
+  if (process.env.NODE_ENV !== 'production') {
+    return NextResponse.next();
+  }
+  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+  const { pathname } = req.nextUrl;
+  if (pathname.startsWith('/api/auth') || pathname === '/access-denied') {
+    return NextResponse.next();
+  }
+  if (!token) {
+    const signInUrl = new URL('/api/auth/signin', req.url);
+    signInUrl.searchParams.set('callbackUrl', req.url);
+    return NextResponse.redirect(signInUrl);
+  }
+  return NextResponse.next();
+}
+
+export const config = { matcher: ['/((?!_next|favicon.ico).*)'] };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,9 @@
     "cytoscape": "^3.32.0",
     "next": "13.4.19",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "next-auth": "^4.24.5",
+    "pg": "^8.11.1"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -1,11 +1,18 @@
 // frontend/pages/_app.js
 import '../styles/globals.css';
 import Layout from '../components/Layout';
+import { SessionProvider } from 'next-auth/react';
 
-export default function MyApp({ Component, pageProps }) {
-  return (
+export default function MyApp({ Component, pageProps: { session, ...pageProps } }) {
+  const isProd = process.env.NODE_ENV === 'production';
+  const content = (
     <Layout>
       <Component {...pageProps} />
     </Layout>
+  );
+  return isProd ? (
+    <SessionProvider session={session}>{content}</SessionProvider>
+  ) : (
+    content
   );
 }

--- a/frontend/pages/access-denied.js
+++ b/frontend/pages/access-denied.js
@@ -1,0 +1,8 @@
+export default function AccessDenied() {
+  return (
+    <div className="text-center mt-10">
+      <h1 className="text-2xl font-bold text-red-600">Access Denied</h1>
+      <p className="mt-4">Your account is not authorized to use this application.</p>
+    </div>
+  );
+}

--- a/frontend/pages/api/auth/[...nextauth].js
+++ b/frontend/pages/api/auth/[...nextauth].js
@@ -1,0 +1,28 @@
+import NextAuth from "next-auth";
+import AzureADProvider from "next-auth/providers/azure-ad";
+import { getAllowedEmails } from "../../../lib/allowedEmails";
+
+export const authOptions = {
+  providers: [
+    AzureADProvider({
+      clientId: process.env.AZURE_AD_CLIENT_ID,
+      clientSecret: process.env.AZURE_AD_CLIENT_SECRET,
+      tenantId: process.env.AZURE_AD_TENANT_ID,
+    }),
+  ],
+  session: { strategy: "jwt" },
+  secret: process.env.NEXTAUTH_SECRET,
+  callbacks: {
+    async signIn({ profile }) {
+      if (process.env.NODE_ENV !== "production") return true;
+      const allowed = await getAllowedEmails();
+      const email = profile?.email?.toLowerCase();
+      if (!email || !allowed.includes(email)) {
+        return "/access-denied";
+      }
+      return true;
+    },
+  },
+};
+
+export default NextAuth(authOptions);


### PR DESCRIPTION
## Summary
- add NextAuth Azure AD provider with allow list support
- enforce auth in frontend middleware
- verify NextAuth session token in FastAPI
- cache allowed emails from env or Postgres
- document Microsoft Entra variables in README
- set NODE_ENV in docker-compose

## Testing
- `npm install --silent` *(in `frontend`)*
- `pip install -r backend/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68464022b2ec832ca4899f2e213af2ec