### PR TITLE
Fix missing SessionProvider

### DIFF
--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -1,11 +1,14 @@
 // frontend/pages/_app.js
 import '../styles/globals.css';
 import Layout from '../components/Layout';
+import { SessionProvider } from 'next-auth/react';
 
 export default function MyApp({ Component, pageProps }) {
   return (
-    <Layout>
-      <Component {...pageProps} />
-    </Layout>
+    <SessionProvider session={pageProps.session}>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </SessionProvider>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the app in `SessionProvider` to allow NextAuth hooks

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68465f00c0c4832cbbbd155cd133e4a2